### PR TITLE
feat: add kernelTracing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i -S @clinic/flame
 
 ## Supported node versions
 
-* Node.js 8 and above
+* Node.js 12 and above
 
 ## Example
 
@@ -47,6 +47,8 @@ const flame = new ClinicFlame()
     **Default**: false
   * dest [`<String>`][] The folder where the collected data is stored.
     **Default**: '.'
+  * kernelTracing [`<boolean>`][] If set to true, it will use `linux_perf` to profile the application.
+    (available only on linux) **Default**: false
 
 #### `flame.collect(args, callback)`
 

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const jsFrameRx = /^([~*])?((?:\S+?\(anonymous function\)|\S+)?(?: [a-zA-Z]+)*) (.*?):(\d+):(\d+)( \[INIT])?( \[INLINABLE])?$/
+const jsFrameRx = /^([~*])?((?:\S+?\(anonymous function\)|\S+)?(?: [a-zA-Z]+)*) (.*?):(\d+)?:?(\d+)( \[INIT])?( \[INLINABLE])?$/
 const wasmFrameRx = /^(.*?) \[WASM:(\w+)]$/
 // This one has the /m flag because regexes may contain \n
 const cppFrameRx = /^(.*) (\[CPP]|\[SHARED_LIB]|\[CODE:\w+])( \[INIT])?$/m
@@ -147,7 +147,7 @@ class FrameNode {
 
     if (/\[CODE:RegExp]$/.test(name)) {
       type = 'regexp'
-    } else if (!/(\.m?js)|(node:)/.test(name)) {
+    } else if (!/(\.m?js)|(node:\w)/.test(name)) {
       if (/\[CODE:.*?]$/.test(name) || /v8::internal::.*\[CPP]$/.test(name)) {
         type = 'v8'
       } else /* istanbul ignore next */ if (/\.$/.test(name)) {

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const jsFrameRx = /^([~*])?((?:\S+?\(anonymous function\)|\S+)?(?: [a-zA-Z]+)*) (.*?):(\d+)?:?(\d+)( \[INIT])?( \[INLINABLE])?$/
+const jsFrameRx = /^([~*^])?((?:\S+?\(anonymous function\)|\S+)?(?: [a-zA-Z]+)*) (.*?):(\d+)?:?(\d+)( \[INIT])?( \[INLINABLE])?$/
 const wasmFrameRx = /^(.*?) \[WASM:(\w+)]$/
 // This one has the /m flag because regexes may contain \n
 const cppFrameRx = /^(.*) (\[CPP]|\[SHARED_LIB]|\[CODE:\w+])( \[INIT])?$/m
@@ -57,8 +57,8 @@ class FrameNode {
       this.columnNumber = parseInt(columnNumber, 10)
       this.isInit = isInit != null
       this.isInlinable = isInlinable != null
-      this.isOptimized = optimizationFlag === '~'
-      this.isUnoptimized = optimizationFlag === '*'
+      this.isOptimized = optimizationFlag === '*'
+      this.isUnoptimized = optimizationFlag === '~' || optimizationFlag === '^'
     } else if ((m = this.name.match(cppFrameRx))) {
       const [
         input, // eslint-disable-line no-unused-vars

--- a/index.js
+++ b/index.js
@@ -21,12 +21,14 @@ class ClinicFlame extends events.EventEmitter {
     const {
       detectPort = false,
       debug = false,
-      dest = null
+      dest = null,
+      kernelTracing = false
     } = settings
 
     this.detectPort = detectPort
     this.debug = debug
     this.path = dest
+    this.kernelTracing = kernelTracing
   }
 
   collect (args, cb) {
@@ -47,6 +49,7 @@ class ClinicFlame extends events.EventEmitter {
       pathToNodeBinary: args[0],
       collectOnly: true,
       writeTicks: true,
+      kernelTracing: this.kernelTracing,
       outputDir: paths['/0x-data/'],
       workingDir: '.' // 0x temporary working files, doesn't support placeholders like {pid}
     }), done)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "@clinic/clinic-common": "^7.0.0",
-    "0x": "^4.10.2",
+    "0x": "^5.0.0",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",
     "d3-fg": "^6.13.1",

--- a/test/analysis-categorise.test.js
+++ b/test/analysis-categorise.test.js
@@ -73,6 +73,14 @@ test('analysis - categorise node names', (t) => {
     category: 'core',
     type: 'core'
   })
+  t.match(byProps({ name: 'node::AsyncWrap::MakeCallback [CPP]' }, linux), {
+    category: 'all-v8',
+    type: 'cpp'
+  })
+  t.match(byProps({ name: '^etag /home/username/app/etag.js:26' }, linux), {
+    category: 'app',
+    type: 'some-app'
+  })
 
   t.equal(byName('/usr/bin/node [SHARED_LIB]', linux), 'cpp')
   t.equal(byName('C:\\Program Files\\nodejs\\node.exe [SHARED_LIB]', windows), 'cpp')
@@ -108,8 +116,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(customNode.type, 'Contains spaces')
   t.equal(customNode.functionName, 'Unexpected multiple customFlags')
   t.equal(customNode.fileName, '.\\sub_dir\\index.js')
-  t.ok(customNode.isOptimized)
-  t.notOk(customNode.isUnoptimized)
+  t.notOk(customNode.isOptimized)
+  t.ok(customNode.isUnoptimized)
   t.notOk(dataTree.isNodeExcluded(customNode))
 
   const depNode = byProps({
@@ -124,8 +132,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(depNode.fileName, '.\\node_modules\\some-module\\index.js')
   t.equal(depNode.lineNumber, 1)
   t.equal(depNode.columnNumber, 2)
-  t.notOk(depNode.isOptimized)
-  t.ok(depNode.isUnoptimized)
+  t.ok(depNode.isOptimized)
+  t.notOk(depNode.isUnoptimized)
   t.notOk(dataTree.isNodeExcluded(depNode))
   dataTree.exclude.add('deps')
   t.ok(dataTree.isNodeExcluded(depNode))
@@ -173,8 +181,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(initNode.fileName, './0x/examples/dummy.js')
   t.ok(initNode.isInit)
   t.notOk(initNode.isInlinable)
-  t.notOk(initNode.isOptimized)
-  t.ok(initNode.isUnoptimized)
+  t.ok(initNode.isOptimized)
+  t.notOk(initNode.isUnoptimized)
 
   t.ok(dataTree.isNodeExcluded(initNode))
 
@@ -214,6 +222,19 @@ test('analysis - categorise node properties', (t) => {
   t.equal(builtinInitNode.functionName, 'ArrayFilter')
   t.equal(builtinInitNode.fileName, null)
   t.ok(builtinInitNode.isInit)
+
+  const perfLine = byProps({
+    name: '^etag /home/username/lib/etag.js:9'
+  }, linux)
+
+  perfLine.format(linux)
+
+  t.equal(perfLine.functionName, 'etag')
+  t.equal(perfLine.fileName, '../home/username/lib/etag.js')
+  t.notOk(perfLine.isInlinable)
+  t.notOk(perfLine.isInit)
+  t.notOk(perfLine.isOptimized)
+  t.ok(perfLine.isUnoptimized)
 
   t.end()
 })


### PR DESCRIPTION
This PR adds support to `kernel-tracing` through 0x.

* fixes optimization flag
* add kernelTracing option
* drop support to node v10 or prior (0x minimum is v12 at v5)
* bump 0x to v5
