### PR TITLE
fix: replace newline escaped to backslashes

### DIFF
--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -11,7 +11,9 @@ class FrameNode {
 
     /* istanbul ignore next: must be a string; can be null but can't replicate in tests */
     // If backslashes have been hard-escaped as their unicode escape char, swap them back in
-    this.name = data.name.replace(/\\u005c/g, '\\') || ''
+    this.name = data.name
+        .replace(/\\u005c/g, '\\')
+        .replace('\n', ' /') || ''
 
     this.onStack = data.value
     this.onStackTop = { base: data.top }

--- a/test/analysis-label-nodes.test.js
+++ b/test/analysis-label-nodes.test.js
@@ -38,3 +38,48 @@ test('analysis - label nodes', (t) => {
 
   t.end()
 })
+
+test('analysis - name escaped \\', (t) => {
+  const rootNode = new FrameNode({
+    name: '~foo\nhome/clinic/clinic-327.js:2:13',
+  })
+
+  const expected = {
+    name: 'foo /home/clinic/clinic-327.js:2:13',
+    id: 0,
+    children: []
+  }
+
+  labelNodes(rootNode)
+  t.match(rootNode.toJSON(), expected)
+
+  t.end()
+})
+
+test('analysis - children name escaped \\', (t) => {
+  const rootNode = new FrameNode({
+    name: '~(anonymous) /home/clinic/clinic-327.js:1:1 [INIT]',
+    children: [{
+      S: 1,
+      name: '~foo\nhome/rafaelgss/repos/os/tests/clinic-327.js:2:13 [INIT]',
+      value: 22,
+      top: 0,
+      isInit: true,
+      fn: 'foo\nhome/rafaelgss/repos/os/tests/clinic-327.js:2:13 [INIT]',
+      children: []
+    }]
+  })
+
+  const expected = {
+    name: '~(anonymous) /home/clinic/clinic-327.js:1:1 [INIT]',
+    id: 0,
+    children: [{
+      name: 'foo /home/rafaelgss/repos/os/tests/clinic-327.js:2:13 [INIT]'
+    }]
+  }
+
+  labelNodes(rootNode)
+  t.match(rootNode.toJSON(), expected)
+
+  t.end()
+})


### PR DESCRIPTION
Address: https://github.com/clinicjs/node-clinic/issues/327﻿

Unfortunately, this is the only thing that we can do from clinicjs/0x side.

It's expected to see `foo\bar` in the call stack, however, the `--prof-process` doesn't parse it properly transforming it into: `~foo\nhome/clinic/clinic-327.js:2:13 [INIT]`.

So, in that situation, the users will see `foo` instead of `foo\bar` in the call-stack. 