### PR TITLE
doc: add issue repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Programmable interface to [Clinic.js][clinic-url] Flame. Learn more about Clinic
 
 ![Screenshot](screenshot.png)
 
+## Issues
+
+To open an issue, please use the [main repository](https://github.com/clinicjs/node-clinic) with the `flame` label.
+
 ## Installation
 
 ```


### PR DESCRIPTION
To improve the maintainability of this project. I've removed the "issues" tab and transferred all the open issues to node-clinic with flame label.